### PR TITLE
Update routes-controllers.md

### DIFF
--- a/knpu/routes-controllers.md
+++ b/knpu/routes-controllers.md
@@ -69,7 +69,7 @@ Pass one argument: the main `knpu_lorem_ipsum.knpu_ipsum` service.
 In Symfony 5, you'll need a bit more config to get your controller service working:
 
 ```xml
-<service id="knpu_lorem_ipsum.ipsum_api_controller" class="KnpU\LoremIpsumBundle\Controller\IpsumApiController" public="true">
+<service id="knpu_lorem_ipsum.controller.ipsum_api_controller" class="KnpU\LoremIpsumBundle\Controller\IpsumApiController" public="true">
     <call method="setContainer">
         <argument type="service" id="Psr\Container\ContainerInterface"/>
     </call>


### PR DESCRIPTION
I've just copied that code snippet "as-is", have not noticed, that `controller` part is absent, and got an error: "The controller for URI "/api/ipsum/" is not callable: Controller `knpu_lorem_ipsum.ipsum_api_controller` does neither exist as service nor as class."